### PR TITLE
Fix Homebrew installation failing on Linux (openssl-sys crate error)

### DIFF
--- a/Formula/kreuzberg.rb
+++ b/Formula/kreuzberg.rb
@@ -19,6 +19,7 @@ class Kreuzberg < Formula
   depends_on "rust" => :build
 
   def install
+    ENV["OPENSSL_DIR"] = Formula["openssl"].opt_prefix 
     system "cargo", "install", "--features", "api,mcp,mcp-http", *std_cargo_args(path: "crates/kreuzberg-cli")
   end
 


### PR DESCRIPTION
When trying to install or upgrade  kreuzberg  via Homebrew on Linux (Linuxbrew), the build fails because the  openssl-sys  crate cannot find OpenSSL via  pkg-config .
Because Homebrew uses a strict build sandbox ( superenv ), it isolates the build environment. This prevents Cargo from accessing the host system’s OpenSSL (like  libssl-dev  on Ubuntu) or Linuxbrew’s OpenSSL, resulting in the following error:
```
Could not find openssl via pkg-config:
pkg-config exited with status code 1
cargo:warning=Could not find directory of OpenSSL installation, and this `-sys` crate cannot proceed without this knowledge.`
```

Solution: To fix this for Linux users, OpenSSL needs to be explicitly declared as a dependency in the Homebrew formula, and the  OPENSSL_DIR  environment variable must be passed to Cargo.
Updating the formula like this resolves the issue:

```
class Kreuzberg < Formula
  # ... existing dependencies ...
  depends_on "pkg-config" => :build
  depends_on "openssl" # Add OpenSSL dependency

  def install
    # Expose the OpenSSL directory to the Rust build process
    ENV["OPENSSL_DIR"] = Formula["openssl"].opt_prefix 
    
    system "cargo", "install", *std_cargo_args(path: "crates/kreuzberg-cli")
  end
end`
```
